### PR TITLE
Remove googleapis-common-protos and protobuf dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ setup(
     install_requires=[
         'GitPython>=3.1.20',
         'immudb-py>=1.4.0',
-        'googleapis-common-protos==1.61.0',
-        'protobuf==3.20.3',
     ],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
Those dependencies are added as workaround of below issue.
  https://github.com/AlmaLinux/build-system/issues/232

The issue was already fixed. See below.
  https://github.com/AlmaLinux/alma-sbom/pull/36
  https://github.com/codenotary/immudb-py/commit/75a46109b86c925057f16b51e3be272394e862a0

So, remove the workaround.